### PR TITLE
fix(FFMPEG): custom ffmpeg arguments failing

### DIFF
--- a/src/audio/AudioResource.ts
+++ b/src/audio/AudioResource.ts
@@ -282,11 +282,11 @@ export function createFFmpegResource(
 ): AudioResource | void {
 	const finalArgs: string[] = [];
 
+	if (typeof input === 'string') finalArgs.push('-i', input);
+	options.inlineVolume ? finalArgs.push(...FFMPEG_PCM_ARGUMENTS) : finalArgs.push(...FFMPEG_OPUS_ARGUMENTS);
 	if (options.arguments && options.arguments.length !== 0) {
 		finalArgs.push(...options.arguments);
 	}
-	if (typeof input === 'string') finalArgs.push('-i', input);
-	options.inlineVolume ? finalArgs.push(...FFMPEG_PCM_ARGUMENTS) : finalArgs.push(...FFMPEG_OPUS_ARGUMENTS);
 	const ffmpegInstance = new FFmpeg({
 		args: finalArgs,
 	});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This moves where options.arguments is appended to finalArgs to after the other steps that append arguments. This ensures custom arguments can behave properly. An example error case is that certain files will fail when appending an argument like '-af atempo=0.5' before '-i', but succeed when placed after.

Note: I'm aware the main @discordjs/voice repo is archived and moved to the monorepo, however I wanted to make this issue with the ffmpeg in built support PR apparent regardless since I was testing with it.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
-->
